### PR TITLE
Add Prashant R to About screen and fix language switcher visibility

### DIFF
--- a/components/LanguageSwitcher.tsx
+++ b/components/LanguageSwitcher.tsx
@@ -1,0 +1,180 @@
+import React, { useState } from 'react';
+import {
+  StyleSheet,
+  Text,
+  View,
+  TouchableOpacity,
+  Modal,
+} from 'react-native';
+import { Ionicons } from '@expo/vector-icons';
+import { useTranslation } from 'react-i18next';
+
+export default function LanguageSwitcher() {
+  const { t, i18n } = useTranslation();
+  const [currentLanguage, setCurrentLanguage] = useState(i18n.language || 'en');
+  const [showLanguageModal, setShowLanguageModal] = useState(false);
+
+  return (
+    <>
+      <TouchableOpacity
+        style={styles.languageButton}
+        onPress={() => setShowLanguageModal(true)}
+        activeOpacity={0.8}
+      >
+        <Ionicons name="language" size={20} color="#374151" />
+        <Text style={styles.languageButtonText}>
+          {currentLanguage.toUpperCase()}
+        </Text>
+        <Ionicons name="chevron-down" size={16} color="#6B7280" />
+      </TouchableOpacity>
+
+      <Modal
+        visible={showLanguageModal}
+        transparent={true}
+        animationType="fade"
+        onRequestClose={() => setShowLanguageModal(false)}
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          activeOpacity={1}
+          onPress={() => setShowLanguageModal(false)}
+        >
+          <View style={styles.languageModal}>
+            <Text style={styles.modalTitle}>{t('selectLanguage')}</Text>
+
+            <TouchableOpacity
+              style={[
+                styles.languageOption,
+                currentLanguage === 'en' && styles.languageOptionSelected,
+              ]}
+              onPress={() => {
+                setCurrentLanguage('en');
+                i18n.changeLanguage('en');
+                setShowLanguageModal(false);
+              }}
+            >
+              <View style={styles.languageOptionContent}>
+                <Text style={styles.languageFlag}>🇺🇸</Text>
+                <Text
+                  style={[
+                    styles.languageOptionText,
+                    currentLanguage === 'en' &&
+                      styles.languageOptionTextSelected,
+                  ]}
+                >
+                  {t('english')}
+                </Text>
+              </View>
+              {currentLanguage === 'en' && (
+                <Ionicons name="checkmark" size={20} color="#3B82F6" />
+              )}
+            </TouchableOpacity>
+
+            <TouchableOpacity
+              style={[
+                styles.languageOption,
+                currentLanguage === 'kn' && styles.languageOptionSelected,
+              ]}
+              onPress={() => {
+                setCurrentLanguage('kn');
+                i18n.changeLanguage('kn');
+                setShowLanguageModal(false);
+              }}
+            >
+              <View style={styles.languageOptionContent}>
+                <Text style={styles.languageFlag}>🇮🇳</Text>
+                <Text
+                  style={[
+                    styles.languageOptionText,
+                    currentLanguage === 'kn' &&
+                      styles.languageOptionTextSelected,
+                  ]}
+                >
+                  {t('kannada')}
+                </Text>
+              </View>
+              {currentLanguage === 'kn' && (
+                <Ionicons name="checkmark" size={20} color="#3B82F6" />
+              )}
+            </TouchableOpacity>
+          </View>
+        </TouchableOpacity>
+      </Modal>
+    </>
+  );
+}
+
+const styles = StyleSheet.create({
+  languageButton: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#F3F4F6',
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 8,
+    gap: 6,
+  },
+  languageButtonText: {
+    fontSize: 12,
+    fontWeight: '600',
+    color: '#374151',
+  },
+  modalOverlay: {
+    flex: 1,
+    backgroundColor: 'rgba(0,0,0,0.5)',
+    justifyContent: 'center',
+    alignItems: 'center',
+    paddingHorizontal: 40,
+  },
+  languageModal: {
+    backgroundColor: '#FFFFFF',
+    borderRadius: 16,
+    padding: 20,
+    width: '100%',
+    maxWidth: 300,
+    shadowColor: '#000',
+    shadowOffset: { width: 0, height: 10 },
+    shadowOpacity: 0.25,
+    shadowRadius: 20,
+    elevation: 10,
+  },
+  modalTitle: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111827',
+    textAlign: 'center',
+    marginBottom: 20,
+  },
+  languageOption: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 12,
+    marginBottom: 8,
+    backgroundColor: '#F9FAFB',
+  },
+  languageOptionSelected: {
+    backgroundColor: '#EBF4FF',
+    borderWidth: 1,
+    borderColor: '#BFDBFE',
+  },
+  languageOptionContent: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  languageFlag: {
+    fontSize: 20,
+  },
+  languageOptionText: {
+    fontSize: 16,
+    fontWeight: '500',
+    color: '#374151',
+  },
+  languageOptionTextSelected: {
+    color: '#1D4ED8',
+    fontWeight: '600',
+  },
+});

--- a/locales/en.json
+++ b/locales/en.json
@@ -100,5 +100,7 @@
   "team_member_manvanth_role": "Developer",
   "team_member_manvanth_description": "Building robust solutions for market transparency",
   "team_member_analysts_role": "Data & Research",
-  "team_member_analysts_description": "Ensuring accurate and real-time market data"
+  "team_member_analysts_description": "Ensuring accurate and real-time market data",
+  "team_member_prashant_role": "Marketing and Research Head",
+  "team_member_prashant_description": "Driving market outreach and research initiatives"
 }

--- a/locales/kn.json
+++ b/locales/kn.json
@@ -100,5 +100,7 @@
 "team_member_manvanth_role": "ಅಭಿವರ್ಧಕ",
 "team_member_manvanth_description": "ಮಾರುಕಟ್ಟೆ ಪಾರದರ್ಶಕತೆಗಾಗಿ ದೃಢವಾದ ಪರಿಹಾರಗಳನ್ನು ನಿರ್ಮಿಸುವುದು",
 "team_member_analysts_role": "ಡೇಟಾ ಮತ್ತು ಸಂಶೋಧನೆ",
-"team_member_analysts_description": "ನಿಖರ ಮತ್ತು ನೈಜ-ಸಮಯದ ಮಾರುಕಟ್ಟೆ ಡೇಟಾವನ್ನು ಖಚಿತಪಡಿಸುವುದು"
+"team_member_analysts_description": "ನಿಖರ ಮತ್ತು ನೈಜ-ಸಮಯದ ಮಾರುಕಟ್ಟೆ ಡೇಟಾವನ್ನು ಖಚಿತಪಡಿಸುವುದು",
+"team_member_prashant_role": "ಮಾರ್ಕೆಟಿಂಗ್ ಮತ್ತು ಸಂಶೋಧನಾ ಮುಖ್ಯಸ್ಥ",
+"team_member_prashant_description": "ಮಾರುಕಟ್ಟೆ ಪ್ರಚಾರ ಮತ್ತು ಸಂಶೋಧನಾ ಉಪಕ್ರಮಗಳನ್ನು ನಡೆಸುವುದು"
 }

--- a/screens/AboutScreen.tsx
+++ b/screens/AboutScreen.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import { Ionicons } from '@expo/vector-icons';
 import Header from '../components/Header';
+import LanguageSwitcher from '../components/LanguageSwitcher';
 import { useTranslation } from 'react-i18next';
 
 const { width } = Dimensions.get('window');
@@ -40,6 +41,13 @@ export default function AboutScreen({ setShowAdminPanel }: { setShowAdminPanel: 
       description: t('team_member_analysts_description'),
       icon: 'analytics',
       color: '#F59E0B',
+    },
+    {
+      name: 'Prashant R',
+      role: t('team_member_prashant_role'),
+      description: t('team_member_prashant_description'),
+      icon: 'search',
+      color: '#8B5CF6',
     },
   ];
 
@@ -125,7 +133,7 @@ export default function AboutScreen({ setShowAdminPanel }: { setShowAdminPanel: 
 
   return (
     <SafeAreaView style={styles.container}>
-      <Header />
+      <Header rightComponent={<LanguageSwitcher />} />
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         {/* Mission Section */}
         <View style={styles.missionSection}>

--- a/screens/HomeScreen.tsx
+++ b/screens/HomeScreen.tsx
@@ -12,7 +12,6 @@ import {
   ScrollView,
   Image,
   Platform,
-  Modal,
   SafeAreaView,
 } from 'react-native';
 import { collection, getDocs, orderBy, query, where, Timestamp } from 'firebase/firestore';
@@ -22,6 +21,7 @@ import { CocoonPrice } from '../types';
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import Header from '../components/Header';
+import LanguageSwitcher from '../components/LanguageSwitcher';
 
 export default function HomeScreen() {
   const { t, i18n } = useTranslation();
@@ -31,11 +31,9 @@ export default function HomeScreen() {
   const [selectedMarket, setSelectedMarket] = useState<string>('all');
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
-  const [currentLanguage, setCurrentLanguage] = useState(i18n.language || 'en');
   const [selectedDate, setSelectedDate] = useState(new Date());
   const [showDatePicker, setShowDatePicker] = useState(false);
   const [availableDates, setAvailableDates] = useState<string[]>([]);
-  const [showLanguageModal, setShowLanguageModal] = useState(false);
   const [isFilterVisible, setIsFilterVisible] = useState(true);
 
   const animatedValues = useRef<Animated.Value[]>([]).current;
@@ -103,15 +101,6 @@ export default function HomeScreen() {
       useNativeDriver: true,
     }).start();
 
-    const handleLanguageChange = (lang: string) => {
-      setCurrentLanguage(lang);
-    };
-
-    i18n.on('languageChanged', handleLanguageChange);
-
-    return () => {
-      i18n.off('languageChanged', handleLanguageChange);
-    };
   }, []);
 
   const animateCards = (itemsToAnimate: CocoonPrice[]) => {
@@ -220,88 +209,6 @@ export default function HomeScreen() {
     </TouchableOpacity>
   );
 
-  const LanguageSwitcher = () => (
-    <>
-      <TouchableOpacity
-        style={styles.languageButton}
-        onPress={() => setShowLanguageModal(true)}
-        activeOpacity={0.8}
-      >
-        <Ionicons name="language" size={20} color="#374151" />
-        <Text style={styles.languageButtonText}>
-          {currentLanguage.toUpperCase()}
-        </Text>
-        <Ionicons name="chevron-down" size={16} color="#6B7280" />
-      </TouchableOpacity>
-
-      <Modal
-        visible={showLanguageModal}
-        transparent={true}
-        animationType="fade"
-        onRequestClose={() => setShowLanguageModal(false)}
-      >
-        <TouchableOpacity
-          style={styles.modalOverlay}
-          activeOpacity={1}
-          onPress={() => setShowLanguageModal(false)}
-        >
-          <View style={styles.languageModal}>
-            <Text style={styles.modalTitle}>{t('selectLanguage')}</Text>
-
-            <TouchableOpacity
-              style={[
-                styles.languageOption,
-                currentLanguage === 'en' && styles.languageOptionSelected
-              ]}
-              onPress={() => {
-                setCurrentLanguage('en');
-                i18n.changeLanguage('en');
-                setShowLanguageModal(false);
-              }}
-            >
-              <View style={styles.languageOptionContent}>
-                <Text style={styles.languageFlag}>🇺🇸</Text>
-                <Text style={[
-                  styles.languageOptionText,
-                  currentLanguage === 'en' && styles.languageOptionTextSelected
-                ]}>
-                  {t('english')}
-                </Text>
-              </View>
-              {currentLanguage === 'en' && (
-                <Ionicons name="checkmark" size={20} color="#3B82F6" />
-              )}
-            </TouchableOpacity>
-
-            <TouchableOpacity
-              style={[
-                styles.languageOption,
-                currentLanguage === 'kn' && styles.languageOptionSelected
-              ]}
-              onPress={() => {
-                setCurrentLanguage('kn');
-                i18n.changeLanguage('kn');
-                setShowLanguageModal(false);
-              }}
-            >
-              <View style={styles.languageOptionContent}>
-                <Text style={styles.languageFlag}>🇮🇳</Text>
-                <Text style={[
-                  styles.languageOptionText,
-                  currentLanguage === 'kn' && styles.languageOptionTextSelected
-                ]}>
-                  {t('kannada')}
-                </Text>
-              </View>
-              {currentLanguage === 'kn' && (
-                <Ionicons name="checkmark" size={20} color="#3B82F6" />
-              )}
-            </TouchableOpacity>
-          </View>
-        </TouchableOpacity>
-      </Modal>
-    </>
-  );
 
   const renderPriceCard = ({ item }: { item: CocoonPrice }) => {
     return (
@@ -603,79 +510,6 @@ const styles = StyleSheet.create({
     fontWeight: '500',
   },
 
-  // Language Button & Modal
-  languageButton: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: 'rgba(255,255,255,0.2)',
-    paddingHorizontal: 12,
-    paddingVertical: 8,
-    borderRadius: 8,
-    gap: 6,
-  },
-  languageButtonText: {
-    fontSize: 12,
-    fontWeight: '600',
-    color: '#FFFFFF',
-  },
-  modalOverlay: {
-    flex: 1,
-    backgroundColor: 'rgba(0,0,0,0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-    paddingHorizontal: 40,
-  },
-  languageModal: {
-    backgroundColor: '#FFFFFF',
-    borderRadius: 16,
-    padding: 20,
-    width: '100%',
-    maxWidth: 300,
-    shadowColor: '#000',
-    shadowOffset: { width: 0, height: 10 },
-    shadowOpacity: 0.25,
-    shadowRadius: 20,
-    elevation: 10,
-  },
-  modalTitle: {
-    fontSize: 18,
-    fontWeight: '700',
-    color: '#111827',
-    textAlign: 'center',
-    marginBottom: 20,
-  },
-  languageOption: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    justifyContent: 'space-between',
-    paddingVertical: 12,
-    paddingHorizontal: 16,
-    borderRadius: 12,
-    marginBottom: 8,
-    backgroundColor: '#F9FAFB',
-  },
-  languageOptionSelected: {
-    backgroundColor: '#EBF4FF',
-    borderWidth: 1,
-    borderColor: '#BFDBFE',
-  },
-  languageOptionContent: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    gap: 12,
-  },
-  languageFlag: {
-    fontSize: 20,
-  },
-  languageOptionText: {
-    fontSize: 16,
-    fontWeight: '500',
-    color: '#374151',
-  },
-  languageOptionTextSelected: {
-    color: '#1D4ED8',
-    fontWeight: '600',
-  },
 
   // Filter Section
   filterHeader: {

--- a/screens/MarketScreen.tsx
+++ b/screens/MarketScreen.tsx
@@ -17,6 +17,7 @@ import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import { collection, getDocs, orderBy, query, where, Timestamp } from 'firebase/firestore';
 import Header from '../components/Header';
+import LanguageSwitcher from '../components/LanguageSwitcher';
 import { db, COLLECTIONS } from '../firebase.config';
 import { CocoonPrice } from '../types';
 import DateTimePicker from '@react-native-community/datetimepicker';
@@ -350,7 +351,7 @@ export default function MarketScreen() {
   if (!showPriceComparison) {
     return (
       <SafeAreaView style={styles.container}>
-        <Header />
+        <Header rightComponent={<LanguageSwitcher />} />
         <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
           <OverviewCard />
 

--- a/screens/StatsScreen.tsx
+++ b/screens/StatsScreen.tsx
@@ -12,6 +12,7 @@ import {
 import { Ionicons } from '@expo/vector-icons';
 import { useTranslation } from 'react-i18next';
 import Header from '../components/Header';
+import LanguageSwitcher from '../components/LanguageSwitcher';
 import { collection, getDocs, orderBy, query } from 'firebase/firestore';
 import { db, COLLECTIONS } from '../firebase.config';
 import { CocoonPrice } from '../types';
@@ -200,7 +201,7 @@ export default function StatsScreen() {
 
   return (
     <SafeAreaView style={styles.container}>
-      <Header />
+      <Header rightComponent={<LanguageSwitcher />} />
       <ScrollView style={styles.content} showsVerticalScrollIndicator={false}>
         <PeriodSelector />
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a unified Language Switcher in the header across Home, Market (when price comparison is hidden), Stats, and About, enabling quick switching between English and Kannada via a modal.
  * Updated the About page with a new team member (Prashant) including role and description.
  * Expanded English and Kannada translations to support new content.
* **Refactor**
  * Replaced the Home screen’s inline language modal with the reusable Language Switcher component.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->